### PR TITLE
Featurebranch

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -50,7 +50,11 @@
                 "${workspaceFolder}/components/Adafruit_NeoPixel",
                 "${workspaceFolder}/components",
                 "${workspaceFolder}/components/arduino/libraries/Update/src",
-                "${workspaceFolder}/components/general/ota/include"
+                "${workspaceFolder}/components/general/ota/include",
+                "${workspaceFolder}/components/ota/include",
+                "${workspaceFolder}/components/NeoPixelBus/src",
+                "${workspaceFolder}/components/arduino/libraries/SPI/src",
+                "${workspaceFolder}/components/arduino/variants/m5stack_fire"
             ],
             "intelliSenseMode": "clang-x64",
             "browse": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -91,7 +91,11 @@
         "fs.h": "c",
         "unity.h": "c",
         "m5display.h": "c",
-        "gittagversion.h": "c"
+        "gittagversion.h": "c",
+        "esp32-hal-dac.h": "c",
+        "esp32-hal.h": "c",
+        "esp32-hal-ledc.h": "c",
+        "arduino.h": "c"
     },
 	"files.exclude": {
 		"**/.git": true,

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -226,4 +226,16 @@ menu "disPOD Configuration"
 
     endmenu
 
+    menu "Display/device timeout configuration"
+
+        config IDLE_TIME_STATUS_SCREEN
+            int "Time (sec) to turn of the device if device is not moved and is not working on initialization/connection. 0 for no shutdown."
+            range 0 600
+            default 300
+        config IDLE_TIME_RUNNING_SCREEN
+            int "Time (sec) to leave running screen if no BLE package is received. 0 to not leave running screen automatically."
+            range 0 600
+            default 300
+    endmenu
+
 endmenu

--- a/main/dispod_gattc.cpp
+++ b/main/dispod_gattc.cpp
@@ -7,7 +7,6 @@
 #include "esp_bt_main.h"
 #include "esp_log.h"
 #include "esp_bt.h"
-#include "esp_gap_ble_api.h"
 #include "esp_gattc_api.h"
 #include "esp_gatt_common_api.h"
 #include "esp_gatt_defs.h"

--- a/main/dispod_idle_timer.cpp
+++ b/main/dispod_idle_timer.cpp
@@ -1,0 +1,43 @@
+#include "dispod_main.h"
+#include "dispod_idle_timer.h"
+
+static const char* TAG = "DISPOD_IDLE_TIMER";
+
+static uint32_t s_count = 0;
+static uint32_t s_duration = 0;
+static bool s_running = false;
+
+void dispod_idle_timer_set(uint32_t duration_ms)
+{
+    s_duration = duration_ms;
+    dispod_touch_timer();
+    s_running = true;
+
+    ESP_LOGI(TAG, "dispod_idle_timer_set(): %u", s_duration);
+}
+
+void dispod_idle_timer_stop()
+{
+    s_running = false;
+    ESP_LOGI(TAG, "dispod_idle_timer_stop()");
+}
+
+void dispod_touch_timer()
+{
+    s_count = millis() + s_duration;
+    ESP_LOGI(TAG, "dispod_touch_timer(): millis = %lu, s_dur = %u, s_count = %u", millis(), s_duration, s_count );
+}
+
+bool dispod_idle_timer_expired()
+{
+    bool expired;
+
+    if(!s_running)
+        return false;
+
+    expired = millis() >= s_count;
+    if(expired)
+        ESP_LOGI(TAG, "dispod_idle_timer_expired(): expired");
+
+    return expired;
+}

--- a/main/dispod_idle_timer.h
+++ b/main/dispod_idle_timer.h
@@ -1,0 +1,9 @@
+#ifndef __DISPOD_IDLE_TIMER_H__
+#define __DISPOD_IDLE_TIMER_H__
+
+void dispod_idle_timer_set(uint32_t duration);
+void dispod_idle_timer_stop();
+bool dispod_idle_timer_expired();
+void dispod_touch_timer();
+
+#endif // __DISPOD_IDLE_TIMER_H__

--- a/main/dispod_ledc.h
+++ b/main/dispod_ledc.h
@@ -1,6 +1,7 @@
 #ifndef __DISPOD_LEDC_H__
 #define __DISPOD_LEDC_H__
 
-void sound(int gpio_num, uint32_t freq, uint32_t duration, uint32_t volume);
+void dispod_init_beep(int gpio_num, uint32_t freq);
+void dispod_beep(uint32_t volume);
 
 #endif // __DISPOD_LEDC_H__

--- a/main/dispod_main.h
+++ b/main/dispod_main.h
@@ -16,6 +16,15 @@
 #include "dispod_tft.h"
 #include "dispod_timer.h"
 
+// IOT param
+typedef struct {
+    uint16_t volume;
+} param_t;
+
+#define PARAM_NAMESPACE "disPOD"
+#define PARAM_KEY       "struct"
+
+
 // disPOD event group
 #define DISPOD_WIFI_ACTIVATED_BIT                   (BIT0)      // WiFi is activated
 #define DISPOD_WIFI_SCANNING_BIT                    (BIT1)      // WiFi scanning for APs

--- a/main/dispod_main.h
+++ b/main/dispod_main.h
@@ -39,7 +39,8 @@
 #define DISPOD_BTN_B_RETRY_BLE_BIT                  (BIT19)
 #define DISPOD_BTN_C_CNT_BIT                        (BIT20)
 #define DISPOD_RUNNING_SCREEN_BIT                   (BIT21)
-#define DISPOD_OTA_RUNNING_BIT                      (BIT22)     // OTA is running and ota_task exists
+#define DISPOD_RUNNING_SCREEN_VOL_BIT               (BIT22)     // allow for metronome sound volume adjustment
+#define DISPOD_OTA_RUNNING_BIT                      (BIT23)     // OTA is running and ota_task exists
 extern EventGroupHandle_t dispod_event_group;
 
 // disPOD SD card event group
@@ -87,8 +88,10 @@ extern dispod_screen_status_t dispod_screen_status;
 // global running values data struct
 extern runningValuesStruct_t running_values;
 
-#define BLE_NAME_FORMAT     "BLE Device (%s)"
-#define WIFI_NAME_FORMAT    "WiFi (%s)"
+#define BLE_NAME_FORMAT         "BLE Device (%s)"
+#define WIFI_NAME_FORMAT        "WiFi (%s)"
+#define STATUS_VOLUME_FORMAT    "Volume: %u"
+#define STATS_QUEUE_FORMAT      "Q: max %u, snd %u, rec %u, fail %u"
 
 // SD card
 #define sdPIN_NUM_MISO 19

--- a/main/dispod_main.h
+++ b/main/dispod_main.h
@@ -6,6 +6,8 @@
 #include "esp_event.h"
 #include "esp_event_loop.h"
 #include "esp_err.h"
+#include "esp_bt_main.h"
+#include "esp_wifi.h"
 #include "freertos/event_groups.h"
 #include "freertos/queue.h"
 #include "driver/ledc.h"
@@ -15,6 +17,7 @@
 #include "dispod_runvalues.h"
 #include "dispod_tft.h"
 #include "dispod_timer.h"
+#include "dispod_idle_timer.h"
 
 // IOT param
 typedef struct {

--- a/main/dispod_tft.cpp
+++ b/main/dispod_tft.cpp
@@ -104,6 +104,9 @@ void dispod_screen_status_initialize(dispod_screen_status_t *params)
     params->q_status.messages_failed    = 0;
     params->show_q_status               = false;
 
+    // voloume
+    params->volume                      = 1;
+
     // create sprites for the building blocks of the status/running screens
     for (int i = 0; i < SCREEN_NUM_SPRITES; i++){
         spr[i] = new TFT_eSprite(&M5.Lcd);
@@ -449,13 +452,13 @@ void dispod_screen_running_update_display(dispod_screen_status_t *params, bool c
     s_draw_indicator(spr[SCREEN_BLOCK_RUNNING_GCT], "GCT", true, MIN_INTERVAL_STANCETIME, 260, values->values_to_display.GCT, MIN_INTERVAL_STANCETIME, MAX_INTERVAL_STANCETIME, complete);
     s_draw_fields(spr[SCREEN_BLOCK_RUNNING_STR],    "Str", 3, values->values_to_display.str / 10., complete);
 
-    // 4) Status text line
-    s_draw_status_text(spr[SCREEN_OVERARCHING_STATUS], params->show_status_text, params->status_text, complete);
-
-    // 5) Statistics text line
-    snprintf(buffer, 64, "Q: max %u, snd %u, rec %u, fail %u",
+    // 4) Statistics text line
+    snprintf(buffer, 64, STATS_QUEUE_FORMAT,
         params->q_status.max_len, params->q_status.messages_send, params->q_status.messages_received, params->q_status.messages_failed);
     s_draw_status_text(spr[SCREEN_OVERARCHING_STATS], params->show_q_status, buffer, complete);
+
+    // 5) Status text line
+    s_draw_status_text(spr[SCREEN_OVERARCHING_STATUS], params->show_status_text, params->status_text, complete);
 
 	// 6) Button label
     s_draw_button_label(spr[SCREEN_OVERARCHING_BUTTON],

--- a/main/dispod_tft.h
+++ b/main/dispod_tft.h
@@ -80,6 +80,7 @@ typedef struct {
 	char                    status_text[32];
     bool                    show_q_status;
     queue_status_t          q_status;
+    uint8_t                 volume;
 } dispod_screen_status_t;
 
 // initialize all display structs
@@ -101,7 +102,7 @@ void dispod_screen_running_update_display();
 
 // queue information
 void dispod_screen_status_update_queue_status(dispod_screen_status_t *params, bool new_show_status);
-void dispod_screen_status_update_queue      (dispod_screen_status_t *params, uint8_t cur_len, bool inc_send, bool inc_received, bool inc_failed);
+void dispod_screen_status_update_queue       (dispod_screen_status_t *params, uint8_t cur_len, bool inc_send, bool inc_received, bool inc_failed);
 
 // function to run in a separate process to update the display using event groups
 void dispod_screen_task(void *pvParameters);

--- a/main/dispod_timer.cpp
+++ b/main/dispod_timer.cpp
@@ -3,6 +3,7 @@
 
 #include "dispod_main.h"
 #include "dispod_timer.h"
+#include "dispod_ledc.h"
 
 static const char* TAG = "DISPOD_TIMER";
 EventGroupHandle_t dispod_timer_evg;
@@ -197,7 +198,8 @@ void dispod_timer_task(void *pvParameters)
 			// Sound on, if activated
             if((xEventGroupWaitBits(dispod_event_group, DISPOD_METRO_SOUND_ACT_BIT, pdFALSE, pdFALSE, 0) & DISPOD_METRO_SOUND_ACT_BIT)){
                 ESP_LOGD(TAG, "dispod_timer_task: DISPOD_METRO_SOUND_ACT_BIT");
-                M5.Speaker.tone(1000);
+                ESP_LOGD(TAG, "beep: vol = %u", dispod_screen_status.volume);
+                dispod_beep(dispod_screen_status.volume);
 				ESP_ERROR_CHECK(esp_timer_start_once(timer_handles[TIMER_METRONOM_OFF_SOUND], METRONOME_SOUND_DURATION_US));
 				ESP_LOGD(TAG, "Started timer TIMER_METRONOM_OFF_SOUND, time since boot: %lld us", esp_timer_get_time());
             }
@@ -216,7 +218,7 @@ void dispod_timer_task(void *pvParameters)
 		if(uxBits & DISPOD_TIMER_METRONOME_OFF_SOUND_BIT){
             ESP_LOGD(TAG, "dispod_timer_task: DISPOD_TIMER_METRONOME_OFF_SOUND_BIT");
 			xEventGroupClearBits(dispod_timer_evg, DISPOD_TIMER_METRONOME_OFF_SOUND_BIT);
-            M5.Speaker.mute();
+            dispod_beep(0);
 			ESP_LOGD(TAG, "Switched off TIMER_METRONOME_OFF_SOUND, time since boot: %lld us", esp_timer_get_time());
         }
 

--- a/main/dispod_update.cpp
+++ b/main/dispod_update.cpp
@@ -31,12 +31,14 @@ void dispod_update_task(void *pvParameters)
                 dispod_runvalues_update_RSCValues(&running_values, new_queue_element.data.rsc.cadance);
                 dispod_check_and_update_display();
                 dispod_archiver_add_RSCValues(new_queue_element.data.rsc.cadance);
+                dispod_touch_timer();
                 break;
             case ID_CUSTOM:
     	        ESP_LOGD(TAG, "received from queue: 0xFF00: Str %1u Sta %4u", new_queue_element.data.custom.str, new_queue_element.data.custom.GCT);
                 dispod_runvalues_update_customValues(&running_values, new_queue_element.data.custom.GCT, new_queue_element.data.custom.str);
                 dispod_check_and_update_display();
                 dispod_archiver_add_customValues(new_queue_element.data.custom.GCT, new_queue_element.data.custom.str);
+                dispod_touch_timer();
                 break;
             case ID_TIME:
 			    strftime(strftime_buf, sizeof(strftime_buf), "%c", &new_queue_element.data.time.timeinfo);

--- a/other_stuff_and_doku_in_work.txt
+++ b/other_stuff_and_doku_in_work.txt
@@ -154,6 +154,10 @@ Queue and event group       https://github.com/hamsternz/esp32_serial_log_to_sd/
 LCD                         https://github.com/espressif/esp-iot-solution/tree/master/components/spi_devices/lcd
 get around flickering w/    https://www.reddit.com/r/esp32/comments/87kp1e/your_experience_with_spi_connected_lcds/
 
+
+
+$ python /home/AKAEM/esp/esp-idf/components/esptool_py/esptool/esptool.py --chip esp32 --port COM6 --baud 921600  --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size detect 0x10000 /home/AKAEM/esp/disPOD/build/dispod.bin
+
 espota.exe -i 192.168.2.155 -p 3232 --auth= -f BLETest.ino.bin
 
 $ ./components/arduino/tools/espota.exe -i 192.168.2.155 -p 3232 --auth= -d -r -f build/dispod.bin
@@ -163,3 +167,19 @@ $ ./components/arduino/tools/espota.exe -i 192.168.2.155 -p 3232 --auth= -d -r -
 Sending invitation to 192.168.2.155
 20:50:04 [INFO]: Waiting for device...
 Uploading: [=================================                           ] 54%
+
+>miniweb -v -i 192.168.2.130 -p 80
+file /dispod.bin
+
+
+
+make erase_flash
+
+make partition_table
+python /home/AKAEM/esp/esp-idf/components/esptool_py/esptool/esptool.py --chip esp32 --port COM6 --baud 921600 --before default_reset --after hard_reset write_flash 0x8000 /home/AKAEM/esp/disPOD/build/partitions.bin
+make partition_table-flash
+
+make flash
+
+python /home/AKAEM/esp/esp-idf/components/esptool_py/esptool/esptool.py --chip esp32 --port COM6 --baud 115200 --before default_reset --after hard_reset write_flash --flash_mode dio --flash_freq 40m --flash_size detect --no-c
+ompress --verify 0xc91000 ./spiffs_image/spiffs_image.img


### PR DESCRIPTION
Beep volume control added
- ledc directly instead of M5.Speaker.tone()
- config using Btn A long press in running screen
- display volume during config in status line
- add screen bit DISPOD_RUNNING_SCREEN_VOL_BIT
- make beep volume persistant using iot_param 

Idle timer functions added
- add IDLE time in status and running screen
- BLE RCS/custom packet -> non-idle
- button press -> non-idle